### PR TITLE
Required version updated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "symfony-bundle",
     "require": {
         "php": ">=5.3.3",
-        "browscap/browscap-php": "1.0.*@dev"
+        "browscap/browscap-php": "*@dev"
     },
     "license": "MIT",
     "minimum-stability": "dev",


### PR DESCRIPTION
When I try to install this bundle with composer, I have the following error.

```
  Problem 1
    - browscap/browscap-bundle 1.0.x-dev requires browscap/browscap-php 1.0.*@dev -> no matching package found.
    - browscap/browscap-bundle dev-master requires browscap/browscap-php 1.0.*@dev -> no matching package found.
```

This PR fixes the problem.
You can also fixe it by adding a tag in `browscap/browscap-php`.
