### PR TITLE
Fix: composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "symfony-bundle",
     "require": {
         "php": ">=5.3.3",
-        "browscap/browscap-php": "*@dev"
+        "garetjax/phpbrowscap": "~2.0"
     },
     "require-dev": {
         "symfony/symfony": ">=2.1,<=2.5"


### PR DESCRIPTION
Correct me if I'm wrong but shouldn't this library depend on `garetjax/phpbrowscap` as stated in the readme? Currently it is depending on `browscap/browscap-php` but the interfaces of both libraries do not match. Personally I would love to see it depending on `browscap/browscap-php` because this seems the officially supported one.
