### PR TITLE
Remove depreacated target-dir usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         }
     },
     "autoload": {
-        "psr-0": { "Browscap\\BrowscapBundle": "" }
-    },
-    "target-dir": "Browscap/BrowscapBundle"
+        "psr-4": { "Browscap\\BrowscapBundle\\": "" }
+    }
 }


### PR DESCRIPTION
Ref: https://getcomposer.org/doc/04-schema.md#target-dir

See also: https://github.com/maglnet/ComposerRequireChecker/issues/55